### PR TITLE
fix: export BaseVersions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,11 @@ import {
   SpawnSyncOptions,
   TestResult,
 } from './runner';
-import { ElectronVersions, Versions } from './versions';
+import { BaseVersions, ElectronVersions, Versions } from './versions';
 import { runFromCommandLine } from './command-line';
 
 export {
+  BaseVersions,
   BisectResult,
   DefaultPaths,
   ElectronVersions,


### PR DESCRIPTION
This base class is useful for test scaffolding: it's (a) closer to using live code than using a mock Version object in jest and (b) easier to use than the ElectronVersions subclass, where version injection requires an http mock to ffake a releases.json payload from electronjs.org.