### PR TITLE
refactor: use async spawn() method for `run` cmd

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -232,18 +232,13 @@ export class Runner {
 
     return new Promise((resolve) => {
       subprocess.on('error', () => {
-        resolve({ status: 'system_error' });
+        return resolve({ status: 'system_error' });
       });
 
       subprocess.on('exit', (code) => {
-        if (code === 0) {
-          resolve({ status: 'test_passed' });
-        }
-        if (code === 1) {
-          resolve({ status: 'test_failed' });
-        }
-
-        resolve({ status: 'test_error' });
+        if (code === 0) return resolve({ status: 'test_passed' });
+        if (code === 1) return resolve({ status: 'test_failed' });
+        return resolve({ status: 'test_error' });
       });
     });
   }


### PR DESCRIPTION
Closes #5

Tested locally in a dumb way:

```
☁  electron-fiddle-runner [refactor/run-async] node lib/index.js test 12.0.2 642fa8daaebea6044c9079e3f8a46390
node lib/index.js test 12.0.2 642fa8daaebea6044c9079e3f8a46390  2.01s user 1.25s system 69% cpu 4.662 total
☁  electron-fiddle-runner [refactor/run-async] echo $?
1
☁  electron-fiddle-runner [refactor/run-async] node lib/index.js test 12.0.0 642fa8daaebea6044c9079e3f8a46390
node lib/index.js test 12.0.0 642fa8daaebea6044c9079e3f8a46390  2.12s user 1.32s system 78% cpu 4.396 total
☁  electron-fiddle-runner [refactor/run-async] echo $?                                                       
0
```