### PR TITLE
refactor: when cloning gists, use --depth=1

### DIFF
--- a/src/fiddle.ts
+++ b/src/fiddle.ts
@@ -59,7 +59,7 @@ export class FiddleFactory {
     if (!fs.existsSync(folder)) {
       d(`cloning "${url}" into "${folder}"`);
       const git = simpleGit();
-      await git.clone(url, folder);
+      await git.clone(url, folder, { '--depth': 1 });
     }
 
     const git = simpleGit(folder);


### PR DESCRIPTION
This avoids pulling in unnecessary history information.

Fixes https://github.com/electron/bugbot/issues/167