### PR TITLE
feat: add ElectronVersions.fetch()

### DIFF
--- a/src/versions.ts
+++ b/src/versions.ts
@@ -240,24 +240,25 @@ export class ElectronVersions extends BaseVersions {
     return new ElectronVersions(versionsCache, now, versions);
   }
 
-  // upate the cache if it's too old
-  private async keepFresh(): Promise<void> {
-    const d = debug('fiddle-core:ElectronVersions:keepFresh');
-
-    // if it's still fresh, do nothing
+  // update the cache
+  public async fetch(): Promise<void> {
+    const d = debug('fiddle-core:ElectronVersions:fetch');
     const { mtimeMs, versionsCache } = this;
-    const now = Date.now();
-    if (ElectronVersions.isCacheFresh(mtimeMs, now)) return;
-
-    // update the cache
     try {
-      this.mtimeMs = now;
+      this.mtimeMs = Date.now();
       const versions = await ElectronVersions.fetchVersions(versionsCache);
       this.setVersions(versions);
       d(`saved "${versionsCache}"`);
     } catch (err) {
       d('error fetching versions', err);
       this.mtimeMs = mtimeMs;
+    }
+  }
+
+  // upate the cache iff it's too old
+  private async keepFresh(): Promise<void> {
+    if (!ElectronVersions.isCacheFresh(this.mtimeMs, Date.now())) {
+      await this.fetch();
     }
   }
 


### PR DESCRIPTION
Add a public method to explicitly fetch a new version list. This feature is needed for Electron Fiddle's "Update Electron Release List" button.

Previously, ElectronVersions would self-check to see if the cache was too old but there was no explicit way to fetch new versions on demand.

Implemented by splitting `ElectronVersions.keepFresh()` into two functions: `ElectronVersions.keepFresh()`, which checks the cache age, and `ElectronVersions.fetch()`, which updates the versions and the cache's mtime.