### PR TITLE
chore: Wrote debug line in catch block instead of comment

### DIFF
--- a/src/versions.ts
+++ b/src/versions.ts
@@ -228,7 +228,7 @@ export class ElectronVersions extends BaseVersions {
       if (ElectronVersions.isCacheFresh(st.mtimeMs, now))
         versions = (await fs.readJson(versionsCache)) as unknown;
     } catch (err) {
-      // cache file missing or cannot be read
+      d('cache file missing or cannot be read', err);
     }
 
     if (!versions) {


### PR DESCRIPTION
While digging through the source code, I found that when processing `VersionsCache` File, If the file doesn't read or found the catch block handles nothing but instead it has a single comment.

I thought this is a great way to improve by handling with `debug` to address this while debugging.