### PR TITLE
refactor: add default parameter for Runner.create

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -53,12 +53,14 @@ export class Runner {
     getos((err, result) => (this.osInfo = inspect(result || err)));
   }
 
-  public static async create(opts: {
-    installer?: Installer;
-    fiddleFactory?: FiddleFactory;
-    paths?: Partial<Paths>;
-    versions?: Versions;
-  }): Promise<Runner> {
+  public static async create(
+    opts: {
+      installer?: Installer;
+      fiddleFactory?: FiddleFactory;
+      paths?: Partial<Paths>;
+      versions?: Versions;
+    } = {},
+  ): Promise<Runner> {
     const paths = Object.freeze({ ...DefaultPaths, ...(opts.paths || {}) });
     const installer = opts.installer || new Installer(paths);
     const versions = opts.versions || (await ElectronVersions.create(paths));

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -63,7 +63,7 @@ describe('Runner', () => {
 
   describe('create()', () => {
     it('creates a Runner object with the expected properties', async () => {
-      const runner = await Runner.create({});
+      const runner = await Runner.create();
       expect(Object.keys(runner)).toEqual([
         'installer',
         'versions',
@@ -171,7 +171,7 @@ describe('Runner', () => {
     ])(
       'can handle a test with the `%s` status',
       async (status, event, exitCode) => {
-        const runner = await Runner.create({});
+        const runner = await Runner.create();
         const fakeSubprocess = new EventEmitter();
         runner.spawn = jest.fn().mockResolvedValue(fakeSubprocess);
 


### PR DESCRIPTION
The `README` documents the usage of `Runner.create` as 
```js
const runner = await Runner.create();
```
which throws an error of object parameters being undefined [here](https://github.com/electron/fiddle-core/blob/e6e2808fedd81981bf4019ddc2711e3e4f905220/src/runner.ts#L56).

Fixed this by adding a default empty object parameter to the `Runner.create` method (which seems like the right way rather than `await Runner.create({})`.