### PR TITLE
docs: fix the given API usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ const result = await runner.bisect('10.0.0', '13.1.7', path_or_gist_or_git_repo)
 import { Installer } from 'fiddle-core';
 
 const installer = new Installer();
-installer.on('state-changed', (version, state) => {
+installer.on('state-changed', ({version, state}) => {
   console.log(`Version "${version}" state changed: "${state}"`);
 });
 


### PR DESCRIPTION
The `.on` function emitter takes in an object parameter. Hence, deconstructed the values first :)
