### PR TITLE
feat: add progress callback handler to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,19 @@ installer.on('state-changed', ({version, state}) => {
 await installer.ensureDownloaded('12.0.15');
 // expect(installer.state('12.0.5').toBe('downloaded');
 
+// download a version with callback
+const callback = (progress: ProgressObject) => {
+  const percent = progress.percent * 100;
+  console.log(`Current download progress %: ${percent.toFixed(2)}`);
+};
+await installer.ensureDownloaded('12.0.15', callback);
+
 // remove a download
 await installer.remove('12.0.15');
 // expect(installer.state('12.0.15').toBe('not-downloaded');
 
 // install a specific version for the runner to use
-const exec = await installer.install('11.4.10');
+const exec = await installer.install('11.4.10'); // callback can be passed here similar to one passed in `ensureDownloaded`
 // expect(installer.state('11.4.10').toBe('installed');
 // expect(fs.accessSync(exec, fs.constants.X_OK)).toBe(true);
 ```

--- a/dist/fiddle-core.d.ts
+++ b/dist/fiddle-core.d.ts
@@ -40,6 +40,8 @@ export declare function compareVersions(a: SemVer, b: SemVer): number;
 
 export declare const DefaultPaths: Paths;
 
+export type ProgressObject = { percent: number };
+
 /**
  * Implementation of Versions that self-populates from release information at
  * https://releases.electronjs.org/releases.json .
@@ -106,10 +108,10 @@ export declare class Installer extends EventEmitter {
     private ensureDownloadedImpl;
     /** map of version string to currently-running active Promise */
     private downloading;
-    ensureDownloaded(version: string): Promise<string>;
+    ensureDownloaded(version: string, progressCallback?: (progress: ProgressObject) => void): Promise<string>;
     /** the currently-installing version, if any */
     private installing;
-    install(version: string): Promise<string>;
+    install(version: string, progressCallback?: (progress: ProgressObject) => void): Promise<string>;
 }
 
 /**

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -71,10 +71,20 @@ describe('Installer', () => {
   }
 
   async function doInstall(installer: Installer, version: string) {
-    const func = () => installer.install(version);
+    let isDownloaded = false;
+    const progressCallback = () => {
+      isDownloaded = true;
+    };
+
+    // Version is already downloaded and present in local
+    if (installer.state(version) !== 'missing') {
+      isDownloaded = true;
+    }
+    const func = () => installer.install(version, progressCallback);
     const { events, result } = await listenWhile(installer, func);
     const exec = result as string;
 
+    expect(isDownloaded).toBe(true);
     expect(installer.state(version)).toBe('installed');
     expect(installer.installedVersion).toBe(version);
 
@@ -82,10 +92,20 @@ describe('Installer', () => {
   }
 
   async function doDownload(installer: Installer, version: string) {
-    const func = () => installer.ensureDownloaded(version);
+    let isDownloaded = false;
+    const progressCallback = () => {
+      isDownloaded = true;
+    };
+
+    // Version is already downloaded and present in local
+    if (installer.state(version) !== 'missing') {
+      isDownloaded = true;
+    }
+    const func = () => installer.ensureDownloaded(version, progressCallback);
     const { events, result } = await listenWhile(installer, func);
     const zipfile = result as string;
 
+    expect(isDownloaded).toBe(true);
     expect(fs.existsSync(zipfile)).toBe(true);
     expect(installer.state(version)).toBe('downloaded');
 


### PR DESCRIPTION
This commit essentially adds the functionality for allowing users to pass a `callback` function to - 
* `Installer.install`
* `Installer.ensureDownloaded`

which is triggered when an electron binary is being downloaded.

#### Usage - 

```ts
import { Installer, ProgressObject } from 'fiddle-core';
const installer = new Installer();


const callback = (progress: ProgressObject) => {
  const percent = progress.percent * 100;
  console.log(`Current download progress %: ${percent.toFixed(2)}`);
};

await installer.ensureDownloaded('12.0.15', callback);
// OR
await installer.install('12.0.15', callback);
```