### PR TITLE
feat: add installing options for electron binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ const result = await runner.bisect('10.0.0', '13.1.7', path_or_gist_or_git_repo)
 ### Managing Electron Installations
 
 ```ts
-import { Installer } from 'fiddle-core';
+import { Installer, ProgressObject } from 'fiddle-core';
 
 const installer = new Installer();
 installer.on('state-changed', ({version, state}) => {
@@ -89,12 +89,37 @@ installer.on('state-changed', ({version, state}) => {
 await installer.ensureDownloaded('12.0.15');
 // expect(installer.state('12.0.5').toBe('downloaded');
 
+// download a version with callback
+const callback = (progress: ProgressObject) => {
+  const percent = progress.percent * 100;
+  console.log(`Current download progress %: ${percent.toFixed(2)}`);
+};
+await installer.ensureDownloaded('12.0.15', {
+  progressCallback: callback,
+});
+
+// download a version with a specific mirror
+const npmMirrors = {
+  electronMirror: 'https://npmmirror.com/mirrors/electron/',
+  electronNightlyMirror: 'https://npmmirror.com/mirrors/electron-nightly/',
+},
+
+await installer.ensureDownloaded('12.0.15', {
+  mirror: npmMirrors,
+});
+
 // remove a download
 await installer.remove('12.0.15');
 // expect(installer.state('12.0.15').toBe('not-downloaded');
 
 // install a specific version for the runner to use
 const exec = await installer.install('11.4.10');
+
+// Installing with callback and custom mirrors
+await installer.install('11.4.10', {
+  progressCallback: callback,
+  mirror: npmMirrors,
+});
 // expect(installer.state('11.4.10').toBe('installed');
 // expect(fs.accessSync(exec, fs.constants.X_OK)).toBe(true);
 ```

--- a/dist/fiddle-core.d.ts
+++ b/dist/fiddle-core.d.ts
@@ -40,6 +40,18 @@ export declare function compareVersions(a: SemVer, b: SemVer): number;
 
 export declare const DefaultPaths: Paths;
 
+export declare type ProgressObject = { percent: number };
+
+export declare interface Mirrors {
+    electronMirror: string;
+    electronNightlyMirror: string;
+}
+
+interface InstallerParams {
+    progressCallback: (progress: ProgressObject) => void;
+    mirror: Mirrors;
+}
+
 /**
  * Implementation of Versions that self-populates from release information at
  * https://releases.electronjs.org/releases.json .
@@ -106,10 +118,10 @@ export declare class Installer extends EventEmitter {
     private ensureDownloadedImpl;
     /** map of version string to currently-running active Promise */
     private downloading;
-    ensureDownloaded(version: string): Promise<string>;
+    ensureDownloaded(version: string, opts?: Partial<InstallerParams>): Promise<string>;
     /** the currently-installing version, if any */
     private installing;
-    install(version: string): Promise<string>;
+    install(version: string, opts?: Partial<InstallerParams>): Promise<string>;
 }
 
 /**

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -71,10 +71,20 @@ describe('Installer', () => {
   }
 
   async function doInstall(installer: Installer, version: string) {
-    const func = () => installer.install(version);
+    let isDownloaded = false;
+    const progressCallback = () => {
+      isDownloaded = true;
+    };
+
+    // Version is already downloaded and present in local
+    if (installer.state(version) !== 'missing') {
+      isDownloaded = true;
+    }
+    const func = () => installer.install(version, { progressCallback });
     const { events, result } = await listenWhile(installer, func);
     const exec = result as string;
 
+    expect(isDownloaded).toBe(true);
     expect(installer.state(version)).toBe('installed');
     expect(installer.installedVersion).toBe(version);
 
@@ -82,10 +92,23 @@ describe('Installer', () => {
   }
 
   async function doDownload(installer: Installer, version: string) {
-    const func = () => installer.ensureDownloaded(version);
+    let isDownloaded = false;
+    const progressCallback = () => {
+      isDownloaded = true;
+    };
+
+    // Version is already downloaded and present in local
+    if (installer.state(version) !== 'missing') {
+      isDownloaded = true;
+    }
+    const func = () =>
+      installer.ensureDownloaded(version, {
+        progressCallback,
+      });
     const { events, result } = await listenWhile(installer, func);
     const zipfile = result as string;
 
+    expect(isDownloaded).toBe(true);
     expect(fs.existsSync(zipfile)).toBe(true);
     expect(installer.state(version)).toBe('downloaded');
 


### PR DESCRIPTION
This commit essentially let users pass an additional parameter to Installer which are handles the downloading process of electron binary.

Basically, the user can now - 

* Pass an a callback function to `ensureDownloaded`/`install` function which is triggered when a binary is being downloaded.
* Downloading electron binary from custom sources by specifying the base mirror.

### Usage 

`progressCallback` - 

```ts
const callback = (progress: ProgressObject) => {
  const percent = progress.percent * 100;
  console.log(`Current download progress %: ${percent.toFixed(2)}`);
};
await installer.ensureDownloaded('12.0.15', {
  progressCallback: callback,
});
```

`mirror` - 

```ts
const myMirror = {
  electronMirror: '<base electron mirror>',
  electronNightlyMirror: '<for nightly version>',
},
await installer.ensureDownloaded('12.0.15', {
  mirror: myMirror,
});
```