### PR TITLE
feat: expose fiddle-core CLI from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "name": "fiddle-core",
   "version": "0.0.2",
   "main": "lib/index.js",
+  "bin": {
+    "fiddle-core": "lib/index.js"
+  },
   "types": "dist/fiddle-core.d.ts",
   "files": [
     "dist/**/*"


### PR DESCRIPTION
`fiddle-core` has CLI functionality, as documented in `README`, but it's not actually exposed. This exposes it so that the examples in the CLI can be run verbatim.