### PR TITLE
fix: fiddle-core failing spawn on Electron deps

### DIFF
--- a/src/fiddle.ts
+++ b/src/fiddle.ts
@@ -45,7 +45,15 @@ export class FiddleFactory {
     const folder = path.join(this.fiddles, hashString(source));
     d({ source, folder });
     await fs.remove(folder);
+
+    // Disable asar in case any deps bundle Electron - ex. @electron/remote
+    // @ts-ignore
+    const { noAsar } = process;
+    // @ts-ignore
+    process.noAsar = true;
     await fs.copy(source, folder);
+    // @ts-ignore
+    process.noAsar = noAsar;
 
     return new Fiddle(path.join(folder, 'main.js'), source);
   }


### PR DESCRIPTION
Closes https://github.com/electron/fiddle/issues/1198.
Refs https://github.com/electron/fiddle/pull/1134.

We need to do something similar to what's done here: https://github.com/electron/fiddle-core/blob/e6387a14ec5d97012a49d63f95e9c86aaf6d74c0/src/installer.ts#L348-L355 and https://github.com/electron/fiddle-core/blob/e6387a14ec5d97012a49d63f95e9c86aaf6d74c0/src/installer.ts#L361-L369 on the off chance that any of the dependencies in `node_modules` themselves bundle Electron.