### PR TITLE
chore: fix linting error

### DIFF
--- a/src/fiddle.ts
+++ b/src/fiddle.ts
@@ -53,7 +53,7 @@ export class FiddleFactory {
     process.noAsar = true;
     await fs.copy(source, folder);
     // @ts-ignore
-    process.noAsar = noAsar;
+    process.noAsar = noAsar; // eslint-disable-line
 
     return new Fiddle(path.join(folder, 'main.js'), source);
   }


### PR DESCRIPTION
Linting error slipped in on #45 because looks like PRs stopped running the CircleCI job (being looked into).