### PR TITLE
chore: add process.noAsar typing as ambient declaration

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,0 +1,5 @@
+declare namespace NodeJS {
+  interface Process {
+    noAsar?: boolean;
+  }
+}

--- a/src/fiddle.ts
+++ b/src/fiddle.ts
@@ -47,13 +47,10 @@ export class FiddleFactory {
     await fs.remove(folder);
 
     // Disable asar in case any deps bundle Electron - ex. @electron/remote
-    // @ts-ignore
     const { noAsar } = process;
-    // @ts-ignore
     process.noAsar = true;
     await fs.copy(source, folder);
-    // @ts-ignore
-    process.noAsar = noAsar; // eslint-disable-line
+    process.noAsar = noAsar;
 
     return new Fiddle(path.join(folder, 'main.js'), source);
   }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -346,26 +346,20 @@ export class Installer extends EventEmitter {
       if (alreadyExtracted) {
         await this.installVersionImpl(version, zipFile, () => {
           // Simply copy over the files from preinstalled version to `electronInstall`
-          // @ts-ignore
           const { noAsar } = process;
-          // @ts-ignore
           process.noAsar = true;
           fs.copySync(zipFile, electronInstall);
-          // @ts-ignore
-          process.noAsar = noAsar; // eslint-disable-line
+          process.noAsar = noAsar;
         });
       } else {
         await this.installVersionImpl(version, zipFile, async () => {
           // FIXME(anyone) is there a less awful way to wrangle asar
-          // @ts-ignore: yes, I know noAsar isn't defined in process
           const { noAsar } = process;
           try {
-            // @ts-ignore: yes, I know noAsar isn't defined in process
             process.noAsar = true;
             await extract(zipFile, { dir: electronInstall });
           } finally {
-            // @ts-ignore: yes, I know noAsar isn't defined in process
-            process.noAsar = noAsar; // eslint-disable-line
+            process.noAsar = noAsar;
           }
         });
       }


### PR DESCRIPTION
Removes the need for @ts-ignore comments when used in code.