### PR TITLE
fix: export ProgressObject type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   InstallState,
   InstallStateEvent,
   ElectronBinary,
+  ProgressObject,
 } from './installer';
 import { Fiddle, FiddleFactory, FiddleSource } from './fiddle';
 import { BisectResult, Runner, RunnerOptions, TestResult } from './runner';
@@ -32,6 +33,7 @@ export {
   InstallStateEvent,
   Installer,
   Paths,
+  ProgressObject,
   Runner,
   RunnerOptions,
   SemOrStr,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -13,7 +13,7 @@ function getZipName(version: string): string {
   return `electron-v${version}-${process.platform}-${process.arch}.zip`;
 }
 
-type ProgressObject = { percent: number };
+export type ProgressObject = { percent: number };
 
 /**
  * The state of a current Electron version.


### PR DESCRIPTION
This needs to be exported (see example in README) but isn't currently.