### PR TITLE
docs: update package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fiddle-Core
+# @electron/fiddle-core
 
 [![CircleCI](https://circleci.com/gh/electron/fiddle-core.svg?style=svg)](https://circleci.com/gh/electron/fiddle-core)
 [![NPM](https://img.shields.io/npm/v/@electron/fiddle-core.svg?style=flat)](https://npmjs.org/package/@electron/fiddle-core)
@@ -45,7 +45,7 @@ Done in 28.19s.
 ### Hello, World!
 
 ```ts
-import { Runner } from 'fiddle-core';
+import { Runner } from '@electron/fiddle-core';
 
 const runner = await Runner.create();
 const { status } = await runner.run('13.1.7', '/path/to/fiddle');
@@ -55,7 +55,7 @@ console.log(status);
 ### Running Fiddles
 
 ```ts
-import { Runner } from 'fiddle-core';
+import { Runner } from '@electron/fiddle-core';
 
 const runner = await Runner.create();
 
@@ -81,7 +81,7 @@ const result = await runner.bisect('10.0.0', '13.1.7', path_or_gist_or_git_repo)
 ### Managing Electron Installations
 
 ```ts
-import { Installer, ProgressObject } from 'fiddle-core';
+import { Installer, ProgressObject } from '@electron/fiddle-core';
 
 const installer = new Installer();
 installer.on('state-changed', ({version, state}) => {
@@ -130,7 +130,7 @@ await installer.install('11.4.10', {
 ### Versions
 
 ```ts
-import { Versions } from 'fiddle-core';
+import { Versions } from '@electron/fiddle-core';
 
 // - querying specific versions
 const elves = await ElectronVersions.create();
@@ -168,7 +168,7 @@ range = releases.inMajor(10);
 ### child_process.Spawn
 
 ```ts
-import { Runner } from 'fiddle-core';
+import { Runner } from '@electron/fiddle-core';
 
 // third argument is same as node.spawn()'s opts
 const child = await runner.spawn('12.0.1', fiddle, nodeSpawnOpts);
@@ -179,7 +179,7 @@ const child = await runner.spawn('12.0.1', fiddle, nodeSpawnOpts);
 ### Using Local Builds
 
 ```ts
-import { Runner } from 'fiddle-core';
+import { Runner } from '@electron/fiddle-core';
 
 const runner = await Runner.create();
 const result = await runner.run('/path/to/electron/build', fiddle);
@@ -188,7 +188,7 @@ const result = await runner.run('/path/to/electron/build', fiddle);
 ### Using Custom Paths
 
 ```ts
-import { Paths, Runner } from 'fiddle-core';
+import { Paths, Runner } from '@electron/fiddle-core';
 
 const paths: Paths = {
   // where to store zipfiles of downloaded electron versions
@@ -213,7 +213,7 @@ Runner will do this work for you; but if you want finer-grained control
 over the lifecycle of your Fiddle objects, you can instantiate them yourself:
 
 ```ts
-import { FiddleFactory } from 'fiddle-core';
+import { FiddleFactory } from '@electron/fiddle-core';
 
 const factory = new FiddleFactory();
 


### PR DESCRIPTION
Examples in the docs didn't get updated for the new package name.