### PR TITLE
fix: re-download zip file if it is missing

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -265,12 +265,13 @@ export class Installer extends EventEmitter {
     const d = debug(`fiddle-core:Installer:${version}:ensureDownloadedImpl`);
     const { electronDownloads } = this.paths;
     const zipFile = path.join(electronDownloads, getZipName(version));
+    const zipFileExists = fs.existsSync(zipFile);
 
     const state = this.state(version);
 
     if (state === InstallState.downloaded) {
       const preInstalledPath = path.join(electronDownloads, version);
-      if (!fs.existsSync(zipFile) && fs.existsSync(preInstalledPath)) {
+      if (!zipFileExists && fs.existsSync(preInstalledPath)) {
         return {
           path: preInstalledPath,
           alreadyExtracted: true,
@@ -278,7 +279,7 @@ export class Installer extends EventEmitter {
       }
     }
 
-    if (state === InstallState.missing) {
+    if (state === InstallState.missing || !zipFileExists) {
       d(`"${zipFile}" does not exist; downloading now`);
       this.setState(version, InstallState.downloading);
       const tempFile = await this.download(version, opts);


### PR DESCRIPTION
Currently, if the zip files for a version get deleted after `Installer` is instantiated, it can't recover and won't re-download the zip. Seeing this error in the Sentry errors for Fiddle.