### PR TITLE
ci: bump Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: npx yarn test:ci
   test-mac:
     macos:
-      xcode: "14.0.0"
+      xcode: "14.3.0"
     parameters:
       node-version:
         description: Node.js version to install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: npx yarn test:ci
   test-mac:
     macos:
-      xcode: "13.0.0"
+      xcode: "14.0.0"
     parameters:
       node-version:
         description: Node.js version to install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
   test-mac:
     macos:
       xcode: "14.3.0"
+    resource_class: macos.x86.medium.gen2
     parameters:
       node-version:
         description: Node.js version to install


### PR DESCRIPTION
The current version is deprecated on CircleCI and will be sunset in the next couple of months.