### PR TITLE
ci: use electronjs/node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   cfa: continuousauth/npm@1.0.2
-  node: electronjs/node@1.1.0
+  node: electronjs/node@1.2.0
 
 workflows:
   test_and_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ workflows:
     # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
       - test:
+          name: test-<< matrix.platform >>-<< matrix.node-version >>
           matrix:
             parameters:
               platform:
@@ -73,7 +74,7 @@ workflows:
                 - macos
                 - windows
               node-version:
-                - 20.4.0
+                - 20.2.0
                 - 18.14.0
                 - 16.19.0
                 - 14.19.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,78 +2,30 @@ version: 2.1
 
 orbs:
   cfa: continuousauth/npm@1.0.2
-  node: circleci/node@5.1.0
-  win: circleci/windows@5.0.0
-
-executors:
-  linux:
-    docker:
-      - image: cimg/base:stable
-  macos:
-    macos:
-      xcode: "14.3.0"
-    resource_class: macos.x86.medium.gen2
-  windows:
-    machine:
-      image: windows-server-2022-gui:stable
-      resource_class: windows.medium
-      shell: bash.exe
-
-commands:
-  install:
-    parameters:
-      node-version:
-        description: Node.js version to install
-        type: string
-    steps:
-      - run: git config --global core.autocrlf input
-      - node/install:
-          node-version: << parameters.node-version >>
-      - run: nvm use << parameters.node-version >>
-      # Can't get yarn installed on Windows with the circleci/node orb, so use npx yarn for commands
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v1-dependencies-{{ arch }}
-      - run: npx yarn install --frozen-lockfile
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
-
-jobs:
-  test:
-    parameters:
-      executor:
-        description: Executor to use
-        type: executor
-      node-version:
-        description: Node.js version to install
-        type: string
-    executor: << parameters.executor >>
-    steps:
-      - install:
-          node-version: << parameters.node-version >>
-      - run: npx yarn test:ci
+  node: electronjs/node@1.1.0
 
 workflows:
   test_and_release:
     # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
-      - test:
+      - node/test:
           name: test-<< matrix.executor >>-<< matrix.node-version >>
+          pre-steps:
+            - run: git config --global core.autocrlf input
+          test-steps:
+            - run: npx yarn test:ci
+          use-test-steps: true
           matrix:
             parameters:
               executor:
-                - linux
-                - macos
-                - windows
+                - node/linux
+                - node/macos
+                - node/windows
               node-version:
                 - 20.2.0
-                - 18.14.0
-                - 16.19.0
-                - 14.19.0
+                - 18.17.0
+                - 16.20.0
+                - 14.21.3
       - cfa/release:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,20 @@ orbs:
   node: circleci/node@5.1.0
   win: circleci/windows@5.0.0
 
+executors:
+  linux:
+    docker:
+      - image: cimg/base:stable
+  macos:
+    macos:
+      xcode: "14.3.0"
+    resource_class: macos.x86.medium.gen2
+  windows:
+    machine:
+      image: windows-server-2022-gui:stable
+      resource_class: windows.medium
+      shell: bash.exe
+
 commands:
   install:
     parameters:
@@ -29,38 +43,19 @@ commands:
           key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
 
 jobs:
-  test-linux:
-    docker:
-      - image: cimg/base:stable
+  test:
     parameters:
+      platform:
+        description: Platform to use
+        enum:
+          - linux
+          - macos
+          - windows
+        type: enum
       node-version:
         description: Node.js version to install
         type: string
-    steps:
-      - install:
-          node-version: << parameters.node-version >>
-      - run: npx yarn test:ci
-  test-mac:
-    macos:
-      xcode: "14.3.0"
-    resource_class: macos.x86.medium.gen2
-    parameters:
-      node-version:
-        description: Node.js version to install
-        type: string
-    steps:
-      - install:
-          node-version: << parameters.node-version >>
-      - run: npx yarn test:ci
-  test-windows:
-    executor:
-      # Need win/default otherwise the nvm-windows version is too old (has bugs)
-      name: win/default
-      shell: bash.exe
-    parameters:
-      node-version:
-        description: Node.js version to install
-        type: string
+    executor: << parameters.platform >>
     steps:
       - install:
           node-version: << parameters.node-version >>
@@ -70,38 +65,21 @@ workflows:
   test_and_release:
     # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
-      - test-linux:
+      - test:
           matrix:
             parameters:
+              platform:
+                - linux
+                - macos
+                - windows
               node-version:
-                - 18.14.0
-                - 16.19.0
-                - 14.19.0
-      - test-mac:
-          matrix:
-            parameters:
-              node-version:
-                - 18.14.0
-                - 16.19.0
-                - 14.19.0
-      - test-windows:
-          matrix:
-            parameters:
-              node-version:
+                - 20.4.0
                 - 18.14.0
                 - 16.19.0
                 - 14.19.0
       - cfa/release:
           requires:
-            - test-linux-18.14.0
-            - test-linux-16.19.0
-            - test-linux-14.19.0
-            - test-mac-18.14.0
-            - test-mac-16.19.0
-            - test-mac-14.19.0
-            - test-windows-18.14.0
-            - test-windows-16.19.0
-            - test-windows-14.19.0
+            - test
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
             - run: npx yarn test:ci
           use-test-steps: true
           matrix:
+            alias: test
             parameters:
               executor:
                 - node/linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,17 +45,13 @@ commands:
 jobs:
   test:
     parameters:
-      platform:
-        description: Platform to use
-        enum:
-          - linux
-          - macos
-          - windows
-        type: enum
+      executor:
+        description: Executor to use
+        type: executor
       node-version:
         description: Node.js version to install
         type: string
-    executor: << parameters.platform >>
+    executor: << parameters.executor >>
     steps:
       - install:
           node-version: << parameters.node-version >>
@@ -66,10 +62,10 @@ workflows:
     # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
       - test:
-          name: test-<< matrix.platform >>-<< matrix.node-version >>
+          name: test-<< matrix.executor >>-<< matrix.node-version >>
           matrix:
             parameters:
-              platform:
+              executor:
                 - linux
                 - macos
                 - windows


### PR DESCRIPTION
Use `electronjs/node` orb to pick up caching of Node.js installs, and significantly simplify this CircleCI config. Also adds Node.js v20 to the matrix.