### PR TITLE
chore: properly filter unsupported Electron versions

### DIFF
--- a/src/versions.ts
+++ b/src/versions.ts
@@ -157,11 +157,18 @@ export class BaseVersions implements Versions {
     // build the array
     let parsed: Array<SemVer | null> = [];
     if (isArrayOfVersionObjects(val)) {
-      parsed = val.map(({ version }) => semverParse(version));
+      parsed = val
+        .map(({ version }) => semverParse(version))
+        .filter((sem) => sem && SemVer.gte(sem.version, '0.30.0')) // Keep >=0.30.0
+        .filter((sem) => !sem.version.startsWith('0.2')); // Exclude atom-shell
 
       // build release info
       for (const entry of val) {
-        if (isReleaseInfo(entry)) {
+        if (
+          isReleaseInfo(entry) &&
+          SemVer.gte(entry.version, '0.30.0') && // Correct comparison
+          !entry.version.startsWith('0.2') // Exclude atom-shell
+        ){
           this.releaseInfo.set(entry.version, {
             version: entry.version,
             date: entry.date,
@@ -177,7 +184,10 @@ export class BaseVersions implements Versions {
         }
       }
     } else if (isArrayOfStrings(val)) {
-      parsed = val.map((version) => semverParse(version));
+      parsed = val
+      .map((version) => semverParse(version))
+      .filter((sem) => sem && SemVer.gte(sem.version, '0.30.0'))
+      .filter((sem) => !sem.version.startsWith('0.2'));
     } else {
       console.warn('Unrecognized versions:', val);
     }

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import { parse as semverParse, SemVer } from 'semver';
+import { parse as semverParse, SemVer, gte } from 'semver';
 import debug from 'debug';
 import fetch from 'node-fetch';
 
@@ -159,15 +159,17 @@ export class BaseVersions implements Versions {
     if (isArrayOfVersionObjects(val)) {
       parsed = val
         .map(({ version }) => semverParse(version))
-        .filter((sem) => sem && SemVer.gte(sem.version, '0.30.0')) // Keep >=0.30.0
+        .filter((sem) => sem && gte(sem, '0.30.0')) // Standalone gte
         .filter((sem) => !sem.version.startsWith('0.2')); // Exclude atom-shell
 
       // build release info
       for (const entry of val) {
+        const parsedVersion = semverParse(entry.version);
         if (
           isReleaseInfo(entry) &&
-          SemVer.gte(entry.version, '0.30.0') && // Correct comparison
-          !entry.version.startsWith('0.2') // Exclude atom-shell
+          parsedVersion &&
+          gte(parsedVersion, '0.30.0') &&
+          !entry.version.startsWith('0.2')
         ){
           this.releaseInfo.set(entry.version, {
             version: entry.version,
@@ -186,7 +188,7 @@ export class BaseVersions implements Versions {
     } else if (isArrayOfStrings(val)) {
       parsed = val
       .map((version) => semverParse(version))
-      .filter((sem) => sem && SemVer.gte(sem.version, '0.30.0'))
+      .filter((sem) => sem && gte(sem, '0.30.0')) 
       .filter((sem) => !sem.version.startsWith('0.2'));
     } else {
       console.warn('Unrecognized versions:', val);


### PR DESCRIPTION
## Description
This PR updates the version filtering logic to properly exclude unsupported Electron versions. Fixes #137 

**Problem:**
- The current implementation doesn't properly filter out:
  - Versions older than 0.30.0
  - Legacy atom-shell versions (0.2.x series)

**Solution:**  
- Implemented dual filtering in `BaseVersions.setVersions()`  
  - `semver.gte()` for minimum version check (≥0.30.0)  
  - Explicit 0.2.x exclusion for atom-shell versions  
- Synchronized release info filtering with version criteria  

## Changes Made
- Updated semver import to include comparison function(gte):
  ```typescript
  import { parse as semverParse, SemVer, gte } from 'semver';

- Added dual filtering in both object and string version handling paths
  ```typescript
  .filter((sem) => sem && gte(sem, '0.30.0'))
  .filter((sem) => !sem.version.startsWith('0.2'))