### PR TITLE
fix: change default git branch from master to main to fix fiddle-core-run

### DIFF
--- a/src/fiddle.ts
+++ b/src/fiddle.ts
@@ -55,7 +55,7 @@ export class FiddleFactory {
     return new Fiddle(path.join(folder, 'main.js'), source);
   }
 
-  public async fromRepo(url: string, checkout = 'master'): Promise<Fiddle> {
+  public async fromRepo(url: string, checkout = 'main'): Promise<Fiddle> {
     const d = debug('fiddle-core:FiddleFactory:fromRepo');
     const folder = path.join(this.fiddles, hashString(url));
     d({ url, checkout, folder });


### PR DESCRIPTION
fiddle-core run 29.0.0 <gist-id>
was giving an error "GitError: error: pathspec 'master' did not match any file(s) known to git" since it was looking for the 'master' branch instead of the default 'main' branch.