### PR TITLE
fix: move cli entrypoint to separate file

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "exports": "./dist/index.js",
   "bin": {
-    "fiddle-core": "dist/index.js"
+    "fiddle-core": "dist/cli.js"
   },
   "files": [
     "dist",
@@ -30,7 +30,7 @@
     "lint:prettier:fix": "prettier --write package.json src/**/*.ts tests/**/*.ts",
     "make": "run-p build",
     "prepublishOnly": "npm run make",
-    "start": "node dist/index.js",
+    "start": "node dist/cli.js",
     "test": "vitest run",
     "test:ci": "vitest run --coverage"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,11 @@
+import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { runFromCommandLine } from './command-line.js';
+
+if (
+  (await fs.promises.realpath(process.argv[1])) ===
+  fileURLToPath(import.meta.url)
+) {
+  void runFromCommandLine(process.argv.slice(2));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-import * as fs from 'node:fs';
-import { fileURLToPath } from 'node:url';
-
 import { DefaultPaths, Paths } from './paths.js';
 import {
   ElectronBinary,
@@ -67,10 +64,3 @@ export {
   compareVersions,
   runFromCommandLine,
 };
-
-if (
-  (await fs.promises.realpath(process.argv[1])) ===
-  fileURLToPath(import.meta.url)
-) {
-  void runFromCommandLine(process.argv.slice(2));
-}


### PR DESCRIPTION
Moves the top-level await currently in `src/index.ts` to a new `src/cli.ts` file and uses that as the entrypoint for the CLI so that we can do `require(esm)` with this package.