### PR TITLE
ci: expand test matrix to arm64 Windows and Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,16 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - 22.12.x
         os:
           - macos-latest
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - windows-latest
+          - windows-11-arm
     runs-on: "${{ matrix.os }}"
     steps:
       - name: Checkout


### PR DESCRIPTION
These are now generally available, so expanding our test matrix to test on these platforms.