### PR TITLE
fix: replace extract-zip with @electron-internal/extract-zip

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,5 +6,6 @@ npmMinimalAgeGate: 10080
 
 npmPreapprovedPackages:
   - "@electron/*"
+  - "@electron-internal/*"
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "test:ci": "vitest run --coverage"
   },
   "dependencies": {
+    "@electron-internal/extract-zip": "^1.0.1",
     "@electron/asar": "^4.0.0",
     "@electron/get": "^5.0.0",
     "debug": "^4.3.3",
     "env-paths": "^3.0.0",
-    "extract-zip": "^2.0.1",
     "graceful-fs": "^4.2.11",
     "semver": "^7.3.5",
     "simple-git": "^3.5.0"

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -5,7 +5,7 @@ import util, { inspect } from 'node:util';
 import fs from 'graceful-fs';
 import semver from 'semver';
 import debug from 'debug';
-import extract from 'extract-zip';
+import { extract } from '@electron-internal/extract-zip';
 import { download as electronDownload } from '@electron/get';
 
 import { DefaultPaths, Paths } from './paths.js';

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -1,18 +1,18 @@
 import os from 'node:os';
 import path from 'node:path';
 
-import extract from 'extract-zip';
+import { extract, type ExtractOptions } from '@electron-internal/extract-zip';
 import fs from 'graceful-fs';
 import nock, { Scope } from 'nock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ElectronBinary, InstallStateEvent, Installer, Paths, InstallState } from '../src/index.js';
 
-vi.mock('extract-zip');
+vi.mock('@electron-internal/extract-zip');
 
-const { default: extractZip } = await vi.importActual<{
-  default: typeof import('extract-zip');
-}>('extract-zip');
+const { extract: extractZip } = await vi.importActual<
+  typeof import('@electron-internal/extract-zip')
+>('@electron-internal/extract-zip');
 
 describe('Installer', () => {
   let tmpdir: string;
@@ -26,7 +26,7 @@ describe('Installer', () => {
   const fixture = (name: string) => path.join(import.meta.dirname, 'fixtures', name);
 
   beforeEach(async () => {
-    vi.mocked(extract).mockImplementation(async (zipPath: string, opts: extract.Options) => {
+    vi.mocked(extract).mockImplementation(async (zipPath: string, opts: ExtractOptions) => {
       await extractZip(zipPath, opts);
     });
     tmpdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'fiddle-core-'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,6 +47,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron-internal/extract-zip@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@electron-internal/extract-zip@npm:1.0.1"
+  checksum: 10c0/4149cb1c99da41457802a11fac692701f58460dcd78341958c10c948876abd3747d45137cf6bfe0c99e7dea0bdb32bf072e9d420a18f55bd1e0087bd1a5c45ba
+  languageName: node
+  linkType: hard
+
 "@electron/asar@npm:^4.0.0":
   version: 4.0.0
   resolution: "@electron/asar@npm:4.0.0"
@@ -64,6 +71,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@electron/fiddle-core@workspace:."
   dependencies:
+    "@electron-internal/extract-zip": "npm:^1.0.1"
     "@electron/asar": "npm:^4.0.0"
     "@electron/get": "npm:^5.0.0"
     "@microsoft/api-extractor": "npm:^7.58.2"
@@ -75,7 +83,6 @@ __metadata:
     "@vitest/coverage-v8": "npm:^4.1.2"
     debug: "npm:^4.3.3"
     env-paths: "npm:^3.0.0"
-    extract-zip: "npm:^2.0.1"
     graceful-fs: "npm:^4.2.11"
     husky: "npm:^9.0.0"
     lint-staged: "npm:^16.0.0"
@@ -886,15 +893,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yauzl@npm:^2.9.1":
-  version: 2.9.2
-  resolution: "@types/yauzl@npm:2.9.2"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/0b4a5db8b7b01e94d9c5f48b5043c22553313e9f31918a9755a4bc7875be92a99bf5f11aa260016f553410be517ce64f5a99b14226d878d65d6d1696869a08b1
-  languageName: node
-  linkType: hard
-
 "@vitest/coverage-v8@npm:^4.1.2":
   version: 4.1.2
   resolution: "@vitest/coverage-v8@npm:4.1.2"
@@ -1117,13 +1115,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-crc32@npm:~0.2.3":
-  version: 0.2.13
-  resolution: "buffer-crc32@npm:0.2.13"
-  checksum: 10c0/cb0a8ddf5cf4f766466db63279e47761eb825693eeba6a5a95ee4ec8cb8f81ede70aa7f9d8aeec083e781d47154290eb5d4d26b3f7a465ec57fb9e7d59c47150
-  languageName: node
-  linkType: hard
-
 "chai@npm:^6.2.2":
   version: 6.2.2
   resolution: "chai@npm:6.2.2"
@@ -1234,15 +1225,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.1.0":
-  version: 1.4.4
-  resolution: "end-of-stream@npm:1.4.4"
-  dependencies:
-    once: "npm:^1.4.0"
-  checksum: 10c0/870b423afb2d54bb8d243c63e07c170409d41e20b47eeef0727547aea5740bd6717aca45597a9f2745525667a6b804c1e7bede41f856818faee5806dd9ff3975
-  languageName: node
-  linkType: hard
-
 "env-paths@npm:^3.0.0":
   version: 3.0.0
   resolution: "env-paths@npm:3.0.0"
@@ -1287,23 +1269,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "extract-zip@npm:2.0.1"
-  dependencies:
-    "@types/yauzl": "npm:^2.9.1"
-    debug: "npm:^4.1.1"
-    get-stream: "npm:^5.1.0"
-    yauzl: "npm:^2.10.0"
-  dependenciesMeta:
-    "@types/yauzl":
-      optional: true
-  bin:
-    extract-zip: cli.js
-  checksum: 10c0/9afbd46854aa15a857ae0341a63a92743a7b89c8779102c3b4ffc207516b2019337353962309f85c66ee3d9092202a83cdc26dbf449a11981272038443974aee
-  languageName: node
-  linkType: hard
-
 "fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -1315,15 +1280,6 @@ __metadata:
   version: 3.1.2
   resolution: "fast-uri@npm:3.1.2"
   checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
-  languageName: node
-  linkType: hard
-
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10c0/304dd70270298e3ffe3bcc05e6f7ade2511acc278bc52d025f8918b48b6aa3b77f10361bddfadfe2a28163f7af7adbdce96f4d22c31b2f648ba2901f0c5fc20e
   languageName: node
   linkType: hard
 
@@ -1386,15 +1342,6 @@ __metadata:
   version: 1.5.0
   resolution: "get-east-asian-width@npm:1.5.0"
   checksum: 10c0/bff8bbc8d81790b9477f7aa55b1806b9f082a8dc1359fff7bd8b96939622c86b729685afc2bfeb22def1fc6ef1e5228e4d87dd4e6da60bc43a5edfb03c4ee167
-  languageName: node
-  linkType: hard
-
-"get-stream@npm:^5.1.0":
-  version: 5.2.0
-  resolution: "get-stream@npm:5.2.0"
-  dependencies:
-    pump: "npm:^3.0.0"
-  checksum: 10c0/43797ffd815fbb26685bf188c8cfebecb8af87b3925091dd7b9a9c915993293d78e3c9e1bce125928ff92f2d0796f3889b92b5ec6d58d1041b574682132e0a80
   languageName: node
   linkType: hard
 
@@ -1910,15 +1857,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.1, once@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "once@npm:1.4.0"
-  dependencies:
-    wrappy: "npm:1"
-  checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
-  languageName: node
-  linkType: hard
-
 "onetime@npm:^7.0.0":
   version: 7.0.0
   resolution: "onetime@npm:7.0.0"
@@ -2144,13 +2082,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pend@npm:~1.2.0":
-  version: 1.2.0
-  resolution: "pend@npm:1.2.0"
-  checksum: 10c0/8a87e63f7a4afcfb0f9f77b39bb92374afc723418b9cb716ee4257689224171002e07768eeade4ecd0e86f1fa3d8f022994219fb45634f2dbd78c6803e452458
-  languageName: node
-  linkType: hard
-
 "picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -2187,16 +2118,6 @@ __metadata:
   version: 2.0.1
   resolution: "propagate@npm:2.0.1"
   checksum: 10c0/01e1023b60ae4050d1a2783f976d7db702022dbdb70dba797cceedad8cfc01b3939c41e77032f8c32aa9d93192fe937ebba1345e8604e5ce61fd3b62ee3003b8
-  languageName: node
-  linkType: hard
-
-"pump@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pump@npm:3.0.0"
-  dependencies:
-    end-of-stream: "npm:^1.1.0"
-    once: "npm:^1.3.1"
-  checksum: 10c0/bbdeda4f747cdf47db97428f3a135728669e56a0ae5f354a9ac5b74556556f5446a46f720a8f14ca2ece5be9b4d5d23c346db02b555f46739934cc6c093a5478
   languageName: node
   linkType: hard
 
@@ -2812,13 +2733,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrappy@npm:1":
-  version: 1.0.2
-  resolution: "wrappy@npm:1.0.2"
-  checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
-  languageName: node
-  linkType: hard
-
 "yallist@npm:^4.0.0":
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
@@ -2832,15 +2746,5 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
-  languageName: node
-  linkType: hard
-
-"yauzl@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
-  dependencies:
-    buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: 10c0/f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
   languageName: node
   linkType: hard


### PR DESCRIPTION
Swaps the `extract-zip` dependency for the `@electron-internal/extract-zip` drop-in replacement.

- Renamed the dependency in `package.json` (`@electron-internal/extract-zip@^1.0.1`)
- Updated import/require specifiers in source
- Added `@electron-internal/*` to the npm age-gate allowlist in `.yarnrc.yml`
- Refreshed `yarn.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)