### PR TITLE
Run spawn with path to electron as working directory 

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -147,16 +147,21 @@ export class Runner {
 
     // set up the electron binary and the fiddle
     const electronExec = await this.getExec(version);
-    let exec =
-      process.platform === 'win32' && opts.runWithIdentity ? MSIX_EXEC_ALIAS : electronExec;
-    let args = [...(opts.args || []), fiddle.mainPath];
-    if (opts.headless) ({ exec, args } = Runner.headless(exec, args));
+    const electronFolder = path.dirname(electronExec);
+    const electronBin = path.basename(electronExec);
 
+    let exec =
+      process.platform === 'win32' && opts.runWithIdentity ? MSIX_EXEC_ALIAS : electronBin;
+
+    let args = [...(opts.args || []), fiddle.mainPath];
+    if (opts.headless) ({ exec, args } = Runner.headless(electronExec, args));
     if (opts.out && opts.showConfig) {
       opts.out.write(`${this.spawnInfo(version, electronExec, fiddle)}\n`);
     }
 
     d(inspect({ exec, args, opts }));
+
+    opts.cwd = electronFolder;
 
     const child = spawn(exec, args, opts);
     if (opts.out) {

--- a/tests/runner.test.ts
+++ b/tests/runner.test.ts
@@ -133,10 +133,11 @@ describe('Runner', () => {
       });
       expect(child_process.spawn).toHaveBeenCalledTimes(1);
       expect(child_process.spawn).toHaveBeenCalledWith(
-        '/path/to/electron/executable',
+        'executable',
         ['/path/to/fiddle/'],
         {
           args: [],
+          cwd: '/path/to/electron',
           headless: false,
           out: expect.any(Object) as Writable,
           showConfig: true,
@@ -172,6 +173,7 @@ describe('Runner', () => {
           ['--auto-servernum', '/path/to/electron/executable', '/path/to/fiddle/'],
           {
             args: [],
+            cwd: '/path/to/electron',
             headless: true,
             out: expect.any(Object) as Writable,
             showConfig: true,
@@ -224,7 +226,7 @@ describe('Runner', () => {
 
       expect(child_process.spawn).toHaveBeenCalledTimes(1);
       expect(child_process.spawn).toHaveBeenCalledWith(
-        '/path/to/electron/executable',
+        'executable',
         ['/path/to/fiddle/app.asar'],
         expect.anything(),
       );


### PR DESCRIPTION
On linux, when a fiddle runs, the path to the electron binary will be something like ` /home/username/.config/Electron Fiddle/electron-bin/current/chrome-sandbox` or something along those lines. But the noteworthy thing here is that the path has a space in it. When `spawn` is passed this as an argument, it thinks `/home/username/.config/Electron` is the binary, and since that doesn't exist, the command won't run and throws an error such as:

```
LaunchProcess: failed to execvp:
/home/username/.config/Electron
```

There's two obvious ways to try and deal with this. The first option is to explore escaping the path. tbh I tried that, it didn't work, so I moved onto the second (and probably better anyway) option, which is to call `spawn` with the name of the binary as the primary argument, and the path to the binary as the `cwd` argument.

This should fix electron/fiddle#1800 and I think electron/fiddle#1598. Without it, I think it's impossible to run fiddle on Ubuntu. I wrote this PR to fix fiddle so I can file a report on electron.